### PR TITLE
[BUG] Fix dynamic_stacking run failure

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,6 +15,7 @@ autogluon:
     presets: best_quality 
     time_limit: 14400
     dynamic_stacking: False
+    num_stack_levels: 0
 llm:
   provider: openai
   api_key_location: OPENAI_API_KEY

--- a/src/autogluon_assistant/predictor.py
+++ b/src/autogluon_assistant/predictor.py
@@ -92,7 +92,13 @@ class AutogluonTabularPredictor(Predictor):
         logger.info(f"predictor_fit_kwargs: {predictor_fit_kwargs}")
 
         if predictor_fit_kwargs.get("dynamic_stacking", False):
-            predictor_fit_kwargs["num_stack_levels"] = 1
+            # Use config value for num_stack_levels
+            # Default 1 if dynamic_stacking is True
+            if predictor_fit_kwargs["num_stack_levels"] == 0:
+                predictor_fit_kwargs["num_stack_levels"] = 1
+            logger.info(
+                f"Dynamic stacking is enabled; setting num_stack_levels={predictor_fit_kwargs['num_stack_levels']}"
+            )
 
         self.metadata |= {
             "predictor_init_kwargs": predictor_init_kwargs,


### PR DESCRIPTION
The following error is raised when running autogluon-assistant with `dynamic_stacking` enabled (see metaflow run id: 247 for more details).

```
omegaconf.errors.ConfigKeyError: Key 'num_stack_levels' is not in struct
    full_key: autogluon.predictor_fit_kwargs.num_stack_levels
    object_type=dict
```

The reason for the error is that num_stack_levels is set here:

https://github.com/autogluon/autogluon-assistant/blob/9b6dd514effb2204fc24ec5fab02ffc7068e1165/src/autogluon_assistant/predictor.py#L95

but the predictor_fit_kwargs is managed by OmegaConf, hence it is required to add the key in config. Setting the default value to 0 here. Also adds ability to change num_stack_levels value from config.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
