### PR TITLE
Fix Dependency Conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "langchain_aws>=0.2.2,<0.3",
     "openfe>=0.0.12,<0.1",
     "pydantic>=2.9.2,<3.0",
-    "caafe@git+https://github.com/gidler/CAAFE.git@main",
     "hydra-core>=1.3",
     "matplotlib>=3.9.2",
     "typer>=0.12.5",
@@ -48,6 +47,9 @@ where = ["src"]
 [tool.setuptools.package-data]
 "autogluon_assistant_tools.config" = ["**/*.yaml"]
 
+[tool.setuptools.build_meta]
+post-install-script = "python -m pip install --no-deps git+https://github.com/gidler/CAAFE.git@main"
+
 [tool.pytest.ini_options]
 testpaths = "tests"
 addopts = "--strict-markers"
@@ -78,7 +80,6 @@ known_third_party = [
 ]
 line_length = 119
 profile = "black"
-
 
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,*.ipynb,*.csv,'


### PR DESCRIPTION
Install caafe without dependency since caafe is not updated for 9 months and is still using langchain==0.0.28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
