### PR TITLE
Optimized description prompt.

### DIFF
--- a/src/autogluon_assistant/prompting/prompt_generator.py
+++ b/src/autogluon_assistant/prompting/prompt_generator.py
@@ -13,6 +13,7 @@ from ..constants import (
     NO_FILE_IDENTIFIED,
     NO_ID_COLUMN_IDENTIFIED,
     PROBLEM_TYPES,
+    TEXT_EXTENSIONS,
 )
 from ..utils import is_text_file
 
@@ -88,9 +89,8 @@ class DescriptionFileNamePromptGenerator(PromptGenerator):
                     truncated_contents = content[:100].strip()
                     if len(content) > 100:
                         truncated_contents += "..."
-                    file_content_prompts += f"File:\n\n{filename}\n\nTruncated Content:\n{truncated_contents}\n\n"
-
-        file_content_prompts += f"Please return the full path of the file to describe the problem settings, and response with the value {NO_FILE_IDENTIFIED} if there's no such file."
+                    file_content_prompts += f"File:\n\n{filename} Truncated Content:\n{truncated_contents}\n\n"
+        file_content_prompts += f"Please return the full path of the file to describe the problem settings, and response with the value {NO_FILE_IDENTIFIED} if there's no such file. the file to describe the problem settings can't be a csv file"
 
         return "\n\n".join(
             [
@@ -117,7 +117,7 @@ class DataFileNamePromptGenerator(PromptGenerator):
                 if len(content.columns) > 10:
                     truncated_columns.append("...")
                 truncated_columns_str = ", ".join(truncated_columns)
-                file_content_prompts += f"File:\n\n{filename}\n\nTruncated Columns:\n{truncated_columns_str}\n\n"
+                file_content_prompts += f"File:\n\n{filename}"#\n\nTruncated Columns:\n{truncated_columns_str}\n\n"
             except Exception as e:
                 print(e)
                 continue


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Claude 3.5 mis-identify the description file as train.csv, such as `bioresponse`. Therefore, I modified the prompt. 
2. `DataFileNamePromptGenerator` can identify the correct train/test/submission fine by its name without showing the columns. I removed it to mitigate the invoke limit problem.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
