### PR TITLE
Enable CAAFE support w latest openai API

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,11 +7,11 @@ save_artifacts:
   path: "./aga-artifacts"
   # path: "s3://autogluon-assistant-agts/outputs/<run_id>/aga-artifacts/"
 feature_transformers:
-  #- _target_: autogluon_assistant.transformer.CAAFETransformer
-  #  eval_model: lightgbm
-  #  llm_model: gpt-3.5-turbo
-  #  num_iterations: 2
-  #  optimization_metric: roc
+  - _target_: autogluon_assistant.transformer.CAAFETransformer
+    eval_model: lightgbm
+    llm_model: gpt-3.5-turbo
+    num_iterations: 2
+    optimization_metric: roc
   - _target_: autogluon_assistant.transformer.OpenFETransformer
     n_jobs: 1
     num_features_to_keep: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "langchain_aws>=0.2.2,<0.3",
     "openfe>=0.0.12,<0.1",
     "pydantic>=2.9.2,<3.0",
+    # CAAFE supporting latest openai API
+    "caafe@git+https://github.com/anirudhdagar/CAAFE.git@main",
     "hydra-core>=1.3",
     "matplotlib>=3.9.2",
     "typer>=0.12.5",


### PR DESCRIPTION
*Issue*
CAAFE was removed in https://github.com/autogluon/autogluon-assistant/pull/41 since the original [project repo](https://github.com/automl/CAAFE) is not updated for 9 months and is still using langchain==0.0.28, and AGA migrated to latest versions of langchain/openai api. I've made the required changes to migrate to the latest OpenAI API according to https://github.com/openai/openai-python/discussions/742 and the current docs https://platform.openai.com/docs/api-reference/chat/create, making the changes on a fork and adding the dependency here to enable CAAFE support again.

*Description of changes:*
All the necessary changes in caafe are here: https://github.com/automl/CAAFE/compare/main...AnirudhDagar:CAAFE:main

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
