### PR TITLE
CAAFE: Use display_method print instead of default markdown

### DIFF
--- a/src/autogluon_assistant/transformer/feature_transformers/caafe.py
+++ b/src/autogluon_assistant/transformer/feature_transformers/caafe.py
@@ -52,7 +52,7 @@ class CAAFETransformer(BaseFeatureTransformer):
             optimization_metric=self.optimization_metric,
             llm_model=self.llm_model,
             iterations=self.iterations,
-            # display_method="print",
+            display_method="print",
         )
 
         self.metadata = {"transformer": "CAAFE"}


### PR DESCRIPTION
*Description of changes:*
@tonyhoo was this line commented out for a specific reason/purpose in https://github.com/autogluon/autogluon-assistant/pull/45?

Without this the markdown display method breaks shell prints and i get the following on the terminal, completely breaking the logs, hence the display_method arg was `"print"`. Enabling it again in this PR.
```
<IPython.core.display.Markdown object>
<IPython.core.display.Markdown object>
<IPython.core.display.Markdown object>
.
.
.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
