### PR TITLE
Fix bedrock region

### DIFF
--- a/src/autogluon_assistant/llm/llm.py
+++ b/src/autogluon_assistant/llm/llm.py
@@ -152,7 +152,7 @@ class LLMFactory:
                 "temperature": config.temperature,
                 "max_tokens": config.max_tokens,
             },
-            region_name=os.getenv("AWS_REGION"),
+            region_name="us-west-2",
             verbose=config.verbose,
         )
 


### PR DESCRIPTION
Bedrock on-demand is only supported in US regions. Fix this to avoid the following error:

```
ERROR:root:Error raised by bedrock service:
An error occurred (ValidationException) when calling the InvokeModel operation:
The provided model doesn't support on-demand throughput.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
