### PR TITLE
Update config: Enable DS defaults; use gpt4 for caafe

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -10,7 +10,7 @@ feature_transformers:
   - _target_: autogluon_assistant.transformer.CAAFETransformer
     eval_model: lightgbm
     llm_model: gpt-4o-2024-08-06
-    num_iterations: 2
+    num_iterations: 5
     optimization_metric: roc
   - _target_: autogluon_assistant.transformer.OpenFETransformer
     n_jobs: 1


### PR DESCRIPTION
*Description of changes:*
AutoGluon by default always turns on Dynamic Stacking. This PR enables that and according to the benchmark run 567, we saw improvement in the average percentile based on these scores.

Also update the caafe model to a stronger gpt4o model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
