### PR TITLE
Fix region_name for getting available bedrock models

### DIFF
--- a/src/autogluon_assistant/llm/llm.py
+++ b/src/autogluon_assistant/llm/llm.py
@@ -113,7 +113,7 @@ class LLMFactory:
     @staticmethod
     def get_bedrock_models() -> List[str]:
         try:
-            bedrock = boto3.client("bedrock")
+            bedrock = boto3.client("bedrock", region_name="us-west-2")
             response = bedrock.list_foundation_models()
             return [
                 model["modelId"]


### PR DESCRIPTION
*Issue #, if available:*

```
AssertionError: anthropic.claude-3-5-sonnet-20241022-v2:0 is not a valid model in: ['anthropic.claude-3-sonnet-20240229-v1:0:28k', 'anthropic.claude-3-sonnet-20240229-v1:0:200k', 'anthropic.claude-3-sonnet-20240229-v1:0', 'anthropic.claude-3-haiku-20240307-v1:0:48k', 'anthropic.claude-3-haiku-20240307-v1:0', 'anthropic.claude-3-5-sonnet-20240620-v1:0'] for provider bedrock
```

*Description:*
`anthropic.claude-3-5-sonnet-20241022-v2:0` is not available in all regions. Since we use `us-west-2` anyway for [ChatBedrock](https://github.com/autogluon/autogluon-assistant/blob/9fe118213ed942b600d954fbcb36aba80421caed/src/autogluon_assistant/llm/llm.py#L170) calls, we should also list and retrieve models available in the same region.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
