### PR TITLE
BUG: Fix feature transform failure when test_id_column=None

### DIFF
--- a/src/autogluon_assistant/transformer/feature_transformers/base.py
+++ b/src/autogluon_assistant/transformer/feature_transformers/base.py
@@ -21,7 +21,7 @@ class BaseFeatureTransformer(BaseTransformer):
     def fit(self, task: TabularPredictionTask) -> "BaseFeatureTransformer":
         try:
             train_x = task.train_data.drop(
-                columns=task.columns_in_train_but_not_test + [task.test_id_column],
+                columns=task.columns_in_train_but_not_test + [task.train_id_column],
                 errors="ignore",
             )
             train_y = task.train_data[task.label_column]
@@ -47,7 +47,7 @@ class BaseFeatureTransformer(BaseTransformer):
     def transform(self, task: TabularPredictionTask) -> TabularPredictionTask:
         try:
             train_x = task.train_data.drop(
-                columns=task.columns_in_train_but_not_test + [task.test_id_column],
+                columns=task.columns_in_train_but_not_test + [task.train_id_column],
                 errors="ignore",
             )
             train_y = task.train_data[task.label_column]
@@ -61,9 +61,9 @@ class BaseFeatureTransformer(BaseTransformer):
 
             # add back id and label columns
             transformed_train_data = pd.concat([train_x, train_y.rename(task.label_column)], axis=1)
-            if task.test_id_column in task.train_data.columns:
+            if task.train_id_column in task.train_data.columns:
                 transformed_train_data = pd.concat(
-                    [transformed_train_data, task.train_data[task.test_id_column]], axis=1
+                    [transformed_train_data, task.train_data[task.train_id_column]], axis=1
                 )
             if task.test_id_column in task.test_data.columns:
                 transformed_test_data = pd.concat([test_x, task.test_data[task.test_id_column]], axis=1)


### PR DESCRIPTION
*Issue:*

```
KeyError: '[None] not found in axis'
> /home/ubuntu/new_oct23/autogluon-assistant/src/autogluon_assistant/transformer/feature_transformers/base.py(54)transform()
-> test_x = task.test_data.drop(columns=[task.test_id_column])
```


*Description of changes:*
This PR checks for the test_id_column presence before dropping it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
