### PR TITLE
CI: remove ssh auth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,8 +22,6 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: |
-        eval `ssh-agent -s`
-        ssh-add - <<< '${{ secrets.PRIVATE_DEPLOY_SSH_KEY }}'
         python -m pip install --upgrade pip
         python -m pip install uv
         uv pip install --system -e ".[dev]"


### PR DESCRIPTION
*Issue #, if available:*
secret keys are not visible for forks causing CI to crash for PRs from forks. Avoid it since we are not installing any private repositories here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
