### PR TITLE
Refine Config Logic

### DIFF
--- a/src/autogluon_assistant/__init__.py
+++ b/src/autogluon_assistant/__init__.py
@@ -2,7 +2,8 @@ import datetime
 import logging
 import os
 from pathlib import Path
-from typing import Optional, List
+from typing import List, Optional
+
 import pandas as pd
 import typer
 from omegaconf import OmegaConf

--- a/src/autogluon_assistant/assistant.py
+++ b/src/autogluon_assistant/assistant.py
@@ -6,11 +6,7 @@ from typing import Any, Dict, Union
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 
-from autogluon_assistant.llm import (
-    AssistantChatBedrock,
-    AssistantChatOpenAI,
-    LLMFactory,
-)
+from autogluon_assistant.llm import AssistantChatBedrock, AssistantChatOpenAI, LLMFactory
 
 from .predictor import AutogluonTabularPredictor
 from .task import TabularPredictionTask

--- a/src/autogluon_assistant/prompting/prompt_generator.py
+++ b/src/autogluon_assistant/prompting/prompt_generator.py
@@ -6,12 +6,7 @@ from langchain.output_parsers import ResponseSchema, StructuredOutputParser
 from langchain.prompts.chat import ChatPromptTemplate
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from ..constants import (
-    METRICS_DESCRIPTION,
-    NO_FILE_IDENTIFIED,
-    NO_ID_COLUMN_IDENTIFIED,
-    PROBLEM_TYPES,
-)
+from ..constants import METRICS_DESCRIPTION, NO_FILE_IDENTIFIED, NO_ID_COLUMN_IDENTIFIED, PROBLEM_TYPES
 from ..utils import is_text_file, load_pd_quietly
 from .utils import get_outer_columns
 


### PR DESCRIPTION
- Fix the issue that aga can only be called in root directory of this repo. https://github.com/autogluon/autogluon-assistant/issues/68
- Change to omegaconf for better preset config support in the future
- Remove hydra and add the config overide logics

Tested with:
`aga ./autogluon-assistant/toy_data`
`aga ./autogluon-assistant/toy_data -c ./autogluon-assistant/config/config.yaml`
`aga ./autogluon-assistant/toy_data -o autogluon.predictor_fit_kwargs.time_limit=60`
`aga ./autogluon-assistant/toy_data -c ./autogluon-assistant/config/config.yaml -o autogluon.predictor_fit_kwargs.time_limit=60`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
