### PR TITLE
Fix #91: Enable Dynamic Stacking as default

### DIFF
--- a/src/autogluon_assistant/predictor.py
+++ b/src/autogluon_assistant/predictor.py
@@ -83,15 +83,6 @@ class AutogluonTabularPredictor(Predictor):
         logger.info(f"predictor_init_kwargs: {predictor_init_kwargs}")
         logger.info(f"predictor_fit_kwargs: {predictor_fit_kwargs}")
 
-        if predictor_fit_kwargs.get("dynamic_stacking", False):
-            # Use config value for num_stack_levels
-            # Default 1 if dynamic_stacking is True
-            if predictor_fit_kwargs["num_stack_levels"] == 0:
-                predictor_fit_kwargs["num_stack_levels"] = 1
-            logger.info(
-                f"Dynamic stacking is enabled; setting num_stack_levels={predictor_fit_kwargs['num_stack_levels']}"
-            )
-
         self.metadata |= {
             "predictor_init_kwargs": predictor_init_kwargs,
             "predictor_fit_kwargs": predictor_fit_kwargs,


### PR DESCRIPTION
*Issue #, if available:*
@boranhan #91 is not enough to enable dynamic stacking, in fact that will cause it to be disabled which is not intended.

*Description of changes:*
This PR removes the logic to check the DS keyword arg in AGA, and lets AG-Tabular handle it with the default preset settings, and hence enabling DS for best_quality preset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
