### PR TITLE
BUG: Fix AG1.2 error; passing problem_type to AG-T

### DIFF
--- a/src/autogluon_assistant/predictor.py
+++ b/src/autogluon_assistant/predictor.py
@@ -74,6 +74,7 @@ class AutogluonTabularPredictor(Predictor):
         predictor_init_kwargs = {
             "learner_kwargs": {"ignored_columns": task.columns_in_train_but_not_test},
             "label": task.label_column,
+            "problem_type": task.problem_type,
             "eval_metric": eval_metric,
             **self.config.predictor_init_kwargs,
         }


### PR DESCRIPTION
*Issue*

See metaflow run `612/run_in_container/17565`.
```
INFO:autogluon.tabular.learner.default_learner:Problem Type:       multiclass
ERROR:root:Exception: Exception
ERROR:root:Traceback (most recent call last):
  File "/app/autogluon-assistant-source/src/autogluon_assistant/assistant.py", line 130, in fit_predictor
    self.predictor.fit(task)
  File "/app/autogluon-assistant-source/src/autogluon_assistant/predictor.py", line 100, in fit
    self.predictor = TabularPredictor(**predictor_init_kwargs).fit(task.train_data, **predictor_fit_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/core/utils/decorators.py", line 31, in _call
    return f(*gargs, **gkwargs)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/tabular/predictor/predictor.py", line 1279, in fit
    self._fit(ag_fit_kwargs=ag_fit_kwargs, ag_post_fit_kwargs=ag_post_fit_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/tabular/predictor/predictor.py", line 1285, in _fit
    self._learner.fit(**ag_fit_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/tabular/learner/abstract_learner.py", line 160, in fit
    return self._fit(X=X, X_val=X_val, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/tabular/learner/default_learner.py", line 88, in _fit
    self._verify_metric(eval_metric=self.eval_metric, problem_type=self.problem_type)
  File "/opt/conda/lib/python3.10/site-packages/autogluon/tabular/learner/abstract_learner.py", line 1113, in _verify_metric
    get_metric(metric=eval_metric.name, problem_type=problem_type, metric_type="eval_metric")
  File "/opt/conda/lib/python3.10/site-packages/autogluon/core/metrics/__init__.py", line 750, in get_metric
    raise ValueError(
ValueError: eval_metric='mean_absolute_error' is not a valid metric for problem_type='multiclass'. Valid problem_types for this metric: ['regression']
Valid metrics for problem_type='multiclass':
['accuracy', 'acc', 'balanced_accuracy', 'mcc', 'log_loss', 'nll', 'pac', 'pac_score', 'quadratic_kappa', 'precision_macro', 'precision_micro', 'precision_weighted', 'recall_macro', 'recall_micro', 'recall_weighted', 'f1_macro', 'f1_micro', 'f1_weighted', 'roc_auc_ovo', 'roc_auc_ovo_macro', 'roc_auc_ovo_weighted', 'roc_auc_ovr', 'roc_auc_ovr_macro', 'roc_auc_ovr_micro', 'roc_auc_ovr_weighted']



```

Even though problem type was being inferred correctly after https://github.com/autogluon/autogluon-assistant/pull/48, it was not used by AG-Tabular and AG-Tabular kept inferring the problem type incorrectly. This PR fixes the same, benchmarks run on AG1.2 (see run 612) break datasets where the evaluation metric doesn't correspond to a correct problem type. This issue caused a failure on `playground-series-s3e16`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
