### PR TITLE
Take in more override config with one call.

### DIFF
--- a/src/autogluon_assistant/utils/configs.py
+++ b/src/autogluon_assistant/utils/configs.py
@@ -70,8 +70,8 @@ def apply_overrides(config: Dict[str, Any], overrides: List[str]) -> Dict[str, A
 
     # Convert overrides to nested dict
     override_conf = {}
-    overrides = ','.join(overrides)
-    overrides = re.split(r'[,\s]+', overrides)
+    overrides = ",".join(overrides)
+    overrides = re.split(r"[,\s]+", overrides)
     for override in overrides:
         key, value = parse_override(override)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Provide more flexibility when using --config_overrides

Previously, only `aga toy_data --config_overrides "feature_transformers=[]" --config_overrides "autogluon.predictor_fit_kwargs.time_limit=3600"` works

After this PR, `aga toy_data --config_overrides "feature_transformers=[], autogluon.predictor_fit_kwargs.time_limit=3600"` will also work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
