### PR TITLE
Fix #106: LLM config script hangs in MacOS; OpenAI Key invalid error

### DIFF
--- a/tools/configure_llms.sh
+++ b/tools/configure_llms.sh
@@ -54,9 +54,9 @@ validate_aws_region() {
 }
 
 # Function to validate API keys
-validate_api_key() {
+validate_openai_api_key() {
     local key=$1
-    [[ $key =~ ^sk.*$ ]] && return 0
+    [[ $key =~ ^sk-[A-Za-z0-9_-]+$ ]] && return 0
     return 1
 }
 
@@ -240,7 +240,7 @@ configure_provider() {
             while true; do
                 echo -n "Enter your OpenAI API Key (starts with sk-): "
                 read OPENAI_API_KEY
-                if validate_api_key "$OPENAI_API_KEY"; then
+                if validate_openai_api_key "$OPENAI_API_KEY"; then
                     break
                 fi
                 print_color "$RED" "Invalid OpenAI API Key format. Please try again."


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes #106.

*Description of changes:*
I've now tested this completely on MacOS and Linux. Also I dropped the `BEDROCK_API_KEY` in the config script following #112. This also fixes the issue with invalid OpenAI API Keys which were actually valid (adding dash and underscore in the matching pattern).

@FANGAreNotGnu could you please also take a look and test it out once. Thanks!
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
