### PR TITLE
Fix sample dataset github download HTTPError: 403 Client Error

### DIFF
--- a/src/autogluon/assistant/ui/pages/task.py
+++ b/src/autogluon/assistant/ui/pages/task.py
@@ -420,7 +420,7 @@ def setup_local_dataset():
     api_url = "https://api.github.com/repos/mli/ag-docs/contents/knot_theory"
     base_url = "https://raw.githubusercontent.com/mli/ag-docs/main/knot_theory/"
 
-    response = requests.get(api_url)
+    response = requests.get(api_url, headers={"User-Agent": "AutoGluon Assistant"})
     response.raise_for_status()
     all_files = response.json()
 


### PR DESCRIPTION
*Issue #, if available:*
similar issue xref: https://github.com/scipy/scipy/issues/21879

From https://github.com/readthedocs/readthedocs.org/issues/11763#issuecomment-2477034172
> Guessing this is GH getting hammered by AI bots, and restricting requests without agents, like the rest of us.

Attaching a screenshot of the error from the AGA UI.
![image](https://github.com/user-attachments/assets/ce066066-edeb-4e3c-8c08-764ad0674c20)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
