### PR TITLE
BUG: Fix #154 Include streamlit conf for build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
 [project]
 name = "autogluon.assistant"
 version = "0.0.1"
@@ -54,7 +55,11 @@ include = ["autogluon.assistant*"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"autogluon.assistant" = ["configs/*.yaml", "ui/**/*"]
+"autogluon.assistant" = [
+    "configs/*.yaml",
+    "ui/**/*",
+    "ui/.streamlit/config.toml"  # Explicitly include the Streamlit config file
+]
 
 [tool.pytest.ini_options]
 testpaths = "tests"
@@ -69,7 +74,6 @@ target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 known_first_party = "autogluon.assistant"
 known_third_party = [
     "autogluon",
-    # "caafe",
     "joblib",
     "langchain",
     "numpy",


### PR DESCRIPTION
## Description
Fix #154 

The issue is with how Unix-style globs handle hidden files and directories (those starting with a dot .). By default, the **/* pattern does not match hidden files or directories. Hence we miss out on `ui/.streamlit/config.toml`

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [ ] Integration tests (if applicable)
- [x] Building python package locally and checking for the presence of `ui/.streamlit/config.toml`. 


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [x] No config changes
- [ ] Config changes (please describe):

## Type of Change
<!-- Check relevant options -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactor
