### PR TITLE
Remove matplotlib dependency

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 ML Assistant for Competitive Machine Learning
-Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AutoGluon Assistant
 
-[![Python Versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)](https://pypi.org/project/autogluon-assistant/)
+[![Python Versions](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)](https://pypi.org/project/autogluon.assistant/)
 [![GitHub license](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![Continuous Integration](https://github.com/autogluon/autogluon-assistant/actions/workflows/lint.yml/badge.svg)](https://github.com/autogluon/autogluon-assistant/actions/workflows/lint.yml)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "langchain_aws>=0.2.2,<0.3",
     "pydantic>=2.9.2,<3.0",
     "hydra-core>=1.3",
-    "matplotlib>=3.9.2",
     "typer>=0.12.5",
     "rich>=13.8.1",
     "s3fs>=2024.9.0",


### PR DESCRIPTION
## Description
I believe matplotlib can be safely removed since it is not an AGA dependency. I also made some minor updates to readme.

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [ ] Integration tests (if applicable)
- [x] Checked locally that we don't use/import matplotlib anywhere. It was probably there since Garrett had it for generating the benchmark plots earlier, and we never cleaned it up after the initial refactor dividing the `autogluon-assistant` and `autogluon-assistant-tools` repo.


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [x] No config changes
- [ ] Config changes (please describe):

## Type of Change
<!-- Check relevant options -->
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [x] Code cleanup/refactor
