### PR TITLE
Add back matplotlib in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "langchain_aws>=0.2.2,<0.3",
     "pydantic>=2.9.2,<3.0",
     "hydra-core>=1.3",
+    # TODO: remove matplotlib later, as it is not used in AGA
+    # but needed for seamless pip install of autogluon.tabular[all]
+    "matplotlib>=3.9.2",
     "typer>=0.12.5",
     "rich>=13.8.1",
     "s3fs>=2024.9.0",


### PR DESCRIPTION
## Description
After merging #159 and removing `matplotlib`, `pip install -e .` is stuck in a loop, because pip's logic for dependency resolution is broken. `uv pip install -e .` still works, but as a work around to make pip install work, we will temporarily add it back to AGA even though it is not required by AGA source.

## How Has This Been Tested?
Created a clean environment and ran

```
pip install -e . --no-cache-dir
```
