### PR TITLE
BUG: Fix custom scorer rmsle

### DIFF
--- a/src/autogluon/assistant/predictor.py
+++ b/src/autogluon/assistant/predictor.py
@@ -17,13 +17,14 @@ logger = logging.getLogger(__name__)
 
 
 def rmsle_func(y_true, y_pred, **kwargs):
+    y_pred = np.clip(y_pred, a_min=0.0, a_max=None)
     return np.sqrt(mean_squared_log_error(y_true, y_pred, **kwargs))
 
 
 root_mean_square_logarithmic_error = make_scorer(
     "root_mean_square_logarithmic_error",
     rmsle_func,
-    optimum=1,
+    optimum=0,
     greater_is_better=False,
 )
 


### PR DESCRIPTION
## Description
Fix ValueError: Mean Squared Logarithmic Error cannot be used when targets contain negative values.
Also correct the scorer as optimum value will be 0 and not 1.

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [ ] Integration tests (if applicable)


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [x] No config changes
- [ ] Config changes (please describe):

## Type of Change
<!-- Check relevant options -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactor
