### PR TITLE
Fix dict config unpack

### DIFF
--- a/src/autogluon/assistant/predictor.py
+++ b/src/autogluon/assistant/predictor.py
@@ -12,6 +12,7 @@ from sklearn.metrics import mean_squared_log_error
 
 from .constants import BINARY, CLASSIFICATION_PROBA_EVAL_METRIC, MULTICLASS
 from .task import TabularPredictionTask
+from .utils import unpack_omega_config
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ class AutogluonTabularPredictor(Predictor):
             "label": task.label_column,
             "problem_type": task.problem_type,
             "eval_metric": eval_metric,
-            **self.config.predictor_init_kwargs,
+            **unpack_omega_config(self.config.predictor_init_kwargs),
         }
         predictor_fit_kwargs = self.config.predictor_fit_kwargs.copy()
         predictor_fit_kwargs.pop("time_limit", None)
@@ -90,7 +91,7 @@ class AutogluonTabularPredictor(Predictor):
         }
         self.save_dataset_details(task)
         self.predictor = TabularPredictor(**predictor_init_kwargs).fit(
-            task.train_data, **predictor_fit_kwargs, time_limit=time_limit
+            task.train_data, **unpack_omega_config(predictor_fit_kwargs), time_limit=time_limit
         )
 
         self.metadata["leaderboard"] = self.predictor.leaderboard().to_dict()

--- a/src/autogluon/assistant/utils/__init__.py
+++ b/src/autogluon/assistant/utils/__init__.py
@@ -1,2 +1,2 @@
-from .configs import get_feature_transformers_config, load_config
+from .configs import get_feature_transformers_config, load_config, unpack_omega_config
 from .files import is_text_file, load_pd_quietly

--- a/src/autogluon/assistant/utils/configs.py
+++ b/src/autogluon/assistant/utils/configs.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from copy import deepcopy
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -182,3 +183,9 @@ def get_feature_transformers_config(config: OmegaConf) -> Optional[List[Dict[str
 
     # Return None if no valid configurations were found
     return transformers_config if transformers_config else None
+
+
+def unpack_omega_config(config):
+    temp_config = deepcopy(config)
+    dict_config = OmegaConf.to_container(temp_config, resolve=True)
+    return dict_config


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Reported by user:
I’m using the command:
aga run Data/ --config_overrides "autogluon.predictor_fit_kwargs.presets=medium_quality" --config_overrides "autogluon.predictor_fit_kwargs.hyperparameters.CAT={}" --config_overrides "autogluon.predictor_fit_kwargs.hyperparameters.GBM={}"
This returns the right configuration for autogluon parameters:
'autogluon': {
        'predictor_init_kwargs': {},
        'predictor_fit_kwargs': {'presets': 'medium_quality', 'hyperparameters': {'CAT': {}, 'GBM': {}}}
However, training stops with an error:
Exception: ("`hyperparameters` must be a dict, but found: <class 'omegaconf.dictconfig.DictConfig'>", 'Predictor Fit')


## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [X] Integration tests (if applicable): `aga run toy_data_newest_backup/ -p medium_quality --config_overrides "autogluon.predictor_fit_kwargs.hyperparameters.CAT={}"`


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [X] No config changes
- [ ] Config changes (please describe):

## Type of Change
<!-- Check relevant options -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactor
