### PR TITLE
Remove unused file loading logic; Fix excel files & Add data loading tests

### DIFF
--- a/src/autogluon/assistant/prompting/prompt_generator.py
+++ b/src/autogluon/assistant/prompting/prompt_generator.py
@@ -13,7 +13,7 @@ from autogluon.assistant.constants import (
     PROBLEM_TYPES,
 )
 from autogluon.assistant.prompting.utils import get_outer_columns
-from autogluon.assistant.utils import is_text_file, load_pd_quietly
+from autogluon.assistant.utils import is_text_file
 
 
 class PromptGenerator(ABC):
@@ -110,18 +110,7 @@ class DataFileNamePromptGenerator(PromptGenerator):
     def generate_prompt(self) -> str:
         file_content_prompts = "# Available Data Files And Columns in The File\n\n"
         for filename in self.filenames:
-            try:
-                content = load_pd_quietly(filename)
-                truncated_columns = content.columns[:10].tolist()
-                if len(content.columns) > 10:
-                    truncated_columns.append("...")
-                # truncated_columns_str = ", ".join(truncated_columns)
-                file_content_prompts += f"File:\n\n{filename}"  # \n\nTruncated Columns:\n{truncated_columns_str}\n\n"
-            except Exception as e:
-                print(
-                    f"Failed to load data as a pandas Dataframe in {filename} with following error (please ignore this if it is not supposed to be a data file): {e}"
-                )
-                continue
+            file_content_prompts += f"File:\n\n{filename}"
 
         file_content_prompts += f"Based on the data description, what are the training, test, and output data? The output file may contain keywords such as benchmark, submission, or output. Please return the full path of the data files as provided, and response with the value {NO_FILE_IDENTIFIED} if there's no such File."
 

--- a/src/autogluon/assistant/task.py
+++ b/src/autogluon/assistant/task.py
@@ -317,8 +317,16 @@ class TabularPredictionTask:
         elif isinstance(dataset, TabularDataset):
             return dataset
         else:
-            filename = dataset.name
-            if filename.split(".")[-1] == ".json":
-                raise TypeError(f"File {filename} has unsupported type: json")
+            if isinstance(dataset, Path):
+                filepath = dataset
+            else:
+                filepath = Path(dataset)
 
-            return TabularDataset(str(dataset))
+            # Check if the file is an Excel file
+            if filepath.suffix in [".xlsx", ".xls"]:
+                df = pd.read_excel(filepath, engine="calamine")
+                return TabularDataset(df)
+            elif filepath.suffix == ".json":
+                raise TypeError(f"File {filepath.name} has unsupported type: json")
+            else:
+                return TabularDataset(str(filepath))

--- a/src/autogluon/assistant/utils/__init__.py
+++ b/src/autogluon/assistant/utils/__init__.py
@@ -1,2 +1,2 @@
 from .configs import get_feature_transformers_config, load_config, unpack_omega_config
-from .files import is_text_file, load_pd_quietly
+from .files import is_text_file

--- a/src/autogluon/assistant/utils/files.py
+++ b/src/autogluon/assistant/utils/files.py
@@ -1,4 +1,5 @@
 import os
+
 from ..constants import TEXT_EXTENSIONS
 
 

--- a/src/autogluon/assistant/utils/files.py
+++ b/src/autogluon/assistant/utils/files.py
@@ -1,38 +1,7 @@
-import contextlib
-import io
-import logging
 import os
-
-from autogluon.tabular import TabularDataset
-
 from ..constants import TEXT_EXTENSIONS
 
 
 def is_text_file(filename):
     _, ext = os.path.splitext(filename)
     return ext.lower() in TEXT_EXTENSIONS
-
-
-@contextlib.contextmanager
-def suppress_tabular_logs():
-    """Context manager to suppress logging output from TabularDataset"""
-    # Save the current logging level
-    logger = logging.getLogger()
-    old_level = logger.getEffectiveLevel()
-
-    # Temporarily increase logging level to suppress INFO logs
-    logger.setLevel(logging.WARNING)
-
-    # Redirect stdout to capture any print statements
-    temp_stdout = io.StringIO()
-    with contextlib.redirect_stdout(temp_stdout):
-        try:
-            yield
-        finally:
-            # Restore the original logging level
-            logger.setLevel(old_level)
-
-
-def load_pd_quietly(filename):
-    with suppress_tabular_logs():
-        return TabularDataset(filename)

--- a/tests/unittests/task/test_data_loading.py
+++ b/tests/unittests/task/test_data_loading.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from autogluon.assistant.constants import TEST, TRAIN
+from autogluon.assistant.task import TabularPredictionTask
+
+
+@pytest.fixture
+def test_data():
+    data = pd.DataFrame({"id": [1, 2, 3], "feature1": [10, 20, 30], "feature2": ["a", "b", "c"], "target": [0, 1, 0]})
+
+    xlsx_path = Path("test.xlsx")
+    xls_path = Path("test.xls")
+
+    try:
+        data.to_excel(xlsx_path, index=False, engine="openpyxl")
+        data.to_excel(xls_path, index=False, engine="openpyxl")
+    except Exception as e:
+        xlsx_path.unlink(missing_ok=True)
+        xls_path.unlink(missing_ok=True)
+        raise RuntimeError(f"Failed to create test files: {str(e)}")
+
+    yield data, xlsx_path, xls_path
+
+    xlsx_path.unlink(missing_ok=True)
+    xls_path.unlink(missing_ok=True)
+
+
+def test_excel_loading(test_data):
+    data, xlsx_path, xls_path = test_data
+
+    task = TabularPredictionTask(
+        name="excel-test",
+        description="Test excel loading functionality",
+        filepaths=[xlsx_path, xls_path],
+        metadata={},
+        cache_data=True,
+    )
+
+    # Test XLSX loading
+    task.dataset_mapping[TRAIN] = xlsx_path
+    original_df = data.copy()
+    original_df.reset_index(drop=True, inplace=True)
+
+    loaded_df = task.train_data
+    loaded_df.reset_index(drop=True, inplace=True)
+    pd.testing.assert_frame_equal(loaded_df, original_df, check_dtype=False)
+
+    # Test XLS loading
+    task.dataset_mapping[TEST] = xls_path
+    loaded_df = task.test_data
+    loaded_df.reset_index(drop=True, inplace=True)
+    pd.testing.assert_frame_equal(loaded_df, original_df, check_dtype=False)
+
+
+def test_excel_loading_without_caching(test_data):
+    _, xlsx_path, xls_path = test_data
+
+    task = TabularPredictionTask(
+        name="excel-test",
+        description="Test excel loading functionality",
+        filepaths=[xlsx_path, xls_path],
+        metadata={},
+        cache_data=False,
+    )
+
+    task.dataset_mapping[TRAIN] = xlsx_path
+    assert isinstance(task.dataset_mapping[TRAIN], Path)
+
+    task.dataset_mapping[TEST] = xls_path
+    assert isinstance(task.dataset_mapping[TEST], Path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/unittests/task/test_task_inference.py
+++ b/tests/unittests/task/test_task_inference.py
@@ -5,12 +5,13 @@ import pytest
 from hydra import compose, initialize
 
 from autogluon.assistant.llm import LLMFactory
-from autogluon.assistant.task import DatasetType, TabularPredictionTask
-from autogluon.assistant.transformer.task_inference import LabelColumnInferenceTransformer
+from autogluon.assistant.task import TabularPredictionTask
+from autogluon.assistant.constants import TRAIN, TEST, OUTPUT
+from autogluon.assistant.task_inference.task_inference import LabelColumnInference
 
-_config_path = "../../../config"
+_config_path = "../../../src/autogluon/assistant/configs"
 with initialize(version_base=None, config_path=_config_path):
-    config = compose(config_name="config")
+    config = compose(config_name="default")
 _llm = LLMFactory.get_chat_model(config.llm)
 
 
@@ -79,12 +80,12 @@ def test_label_column_inference(toy_multiclass_data):
         cache_data=False,
     )
 
-    task.dataset_mapping[DatasetType.TRAIN] = train
-    task.dataset_mapping[DatasetType.TEST] = test
-    task.dataset_mapping[DatasetType.OUTPUT] = sample_submission
+    task.dataset_mapping[TRAIN] = train
+    task.dataset_mapping[TEST] = test
+    task.dataset_mapping[OUTPUT] = sample_submission
 
     # this won't guarantee a test for fallback logic since LLM will work most probably
-    transformer = LabelColumnInferenceTransformer(_llm)
+    transformer = LabelColumnInference(_llm)
     task = transformer.transform(task)
     assert task.metadata["label_column"] == "OutcomeType", "The label column should be 'OutcomeType'."
 

--- a/tests/unittests/task/test_task_inference.py
+++ b/tests/unittests/task/test_task_inference.py
@@ -4,9 +4,9 @@ import pandas as pd
 import pytest
 from hydra import compose, initialize
 
+from autogluon.assistant.constants import OUTPUT, TEST, TRAIN
 from autogluon.assistant.llm import LLMFactory
 from autogluon.assistant.task import TabularPredictionTask
-from autogluon.assistant.constants import TRAIN, TEST, OUTPUT
 from autogluon.assistant.task_inference.task_inference import LabelColumnInference
 
 _config_path = "../../../src/autogluon/assistant/configs"


### PR DESCRIPTION
## Description
`truncated_columns_str` and file contents are not used, we can safely remove this piece of code. Also this causes a bug reported by an internal user when loading excel files. We depend on pandas with python calamine engine for excel files, and `load_pd_quietly` directly use AG-T `TabularDataset` which only supports csv, parquet files.

Also fixes `load_task_data` which was not handling excel files before, and adds tests for excel data.

This PR fixes the excel issue, as well as cleans up the dead code.

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [x] Unit tests (`pytest tests/`)
- [ ] Integration tests (if applicable)

`pytest -v tests/unittests/task/test_data_loading.py`


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [x] No config changes
- [ ] Config changes (please describe):

## Type of Change
<!-- Check relevant options -->
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup/refactor
