### PR TITLE
Fix Version Conflicts Between Transformers and Accelerator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
 ]
 dependencies = [
   "langgraph",
+  "accelerate<1.0",
   "autogluon==1.2.0",
   "autogluon.tabular[skex]==1.2.0",
   "chardet>=5.2.0",
@@ -34,6 +35,7 @@ dependencies = [
   "joblib>=1.4.2",
   "python-calamine",
   "tenacity>=8.2.2",
+  "transformers<=4.49.0",
   "pandas>=2.2",
   "streamlit>=1.37",
   "streamlit-aggrid>=1.0.2",


### PR DESCRIPTION
## Description
ImportError: cannot import name 'TorchTensorParallelPlugin' from 'accelerate.utils' (/home/runner/miniconda3/envs/assistant_py3/lib/python3.10/site-packages/accelerate/utils/__init__.py)

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [X] Integration tests (if applicable)
- [ ] If there is a new feature, please describe how you test it:


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [X] No config changes
- [ ] Config changes have been updated in `default.yaml`. Please describe the changes:

## Type of Change
<!-- Check relevant options -->
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactor
