### PR TITLE
Remove Unnecessary Prompt

### DIFF
--- a/src/autogluon/assistant/prompts/bash_coder_prompt.py
+++ b/src/autogluon/assistant/prompts/bash_coder_prompt.py
@@ -89,7 +89,7 @@ Create and configure a conda environment in "{ENV_FOLDER_NAME}" folder under {it
  - Install required packages from {common_env_file} and {selected_tool_env_file} using uv pip install -r {selected_tool_env_file} -r {common_env_file}"""
 
         if not create_venv:
-            env_prompt += f"\n - Do not install or update any package unless there is an error due to the missing package.\n - Do NOT upgrade {selected_tool} which is already installed."
+            env_prompt += f"\n - Do not install or update any package unless there is an error due to the missing package.\n"
         else:
             env_prompt += "\n - Install any packages that are needed in the python script"
 


### PR DESCRIPTION
## Description
It causes `Because wav2vec2 was not found in the package registry and you require wav2vec2, we can conclude that your requirements are unsatisfiable.` with code `uv pip install -r "$WAV2VEC2_REQS" -r "$COMMON_REQS" --no-upgrade wav2vec2`

## How Has This Been Tested?
<!-- Please describe how you tested your changes -->
- [ ] Unit tests (`pytest tests/`)
- [ ] Integration tests (if applicable)
- [ ] If there is a new feature, please describe how you test it:


## Configuration Changes
<!-- Note any changes to configuration files or environment variables -->
- [ ] No config changes
- [ ] Config changes have been updated in `default.yaml`. Please describe the changes:

## Type of Change
<!-- Check relevant options -->
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactor
